### PR TITLE
PX4IO interface protocol: Fix float to int16_t conversion error

### DIFF
--- a/src/modules/px4iofirmware/protocol.h
+++ b/src/modules/px4iofirmware/protocol.h
@@ -74,7 +74,7 @@
 #define SIGNED_TO_REG(_signed)	((uint16_t)(_signed))
 
 #define REG_TO_FLOAT(_reg)	((float)REG_TO_SIGNED(_reg) / 10000.0f)
-#define FLOAT_TO_REG(_float)	SIGNED_TO_REG((int16_t)((_float) * 10000.0f))
+#define FLOAT_TO_REG(_float)	SIGNED_TO_REG((int16_t)floorf((_float + 0.00005f) * 10000.0f))
 
 #define PX4IO_PROTOCOL_VERSION		4
 


### PR DESCRIPTION
See https://github.com/PX4/Firmware/pull/7644